### PR TITLE
update ignore paths for codeql

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -5,6 +5,6 @@ queries:
 
 paths-ignore: 
     # Ignore all files with the .Designer.cs extension (generated code)
-  - *.Designer.cs
+  - '*.Designer.cs'
    # Ignore all files with the .generated.cs extension (generated code)
-  - *.generated.cs
+  - '*.generated.cs'

--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -4,4 +4,7 @@ queries:
   - uses: security-and-quality
 
 paths-ignore: 
-  - '/ClientNoSqlDB.Samples.Maui/obj'
+    # Ignore all files with the .Designer.cs extension (generated code)
+  -*.Designer.cs
+   # Ignore all files with the .generated.cs extension (generated code)
+  -*.generated.cs

--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -5,6 +5,6 @@ queries:
 
 paths-ignore: 
     # Ignore all files with the .Designer.cs extension (generated code)
-  -*.Designer.cs
+  - *.Designer.cs
    # Ignore all files with the .generated.cs extension (generated code)
-  -*.generated.cs
+  - *.generated.cs

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -39,7 +39,7 @@ jobs:
       uses: actions/setup-java@v4
       with:
           distribution: 'microsoft' 
-          java-version: 11
+          java-version: 17
     - name: search workloads
       run: dotnet workload search
     - name: restore workloads

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -24,7 +24,7 @@ jobs:
       uses: actions/setup-java@v4
       with:
         distribution: 'microsoft' 
-        java-version: 11
+        java-version: 17
     - name: search workloads
       run: dotnet workload search
     - name: restore workloads


### PR DESCRIPTION
This pull request includes changes to the `.github/codeql/codeql-config.yml` file to refine the paths ignored during the CodeQL analysis. The most important changes involve adding new patterns to ignore generated code files.

CodeQL configuration updates:

* [`.github/codeql/codeql-config.yml`](diffhunk://#diff-3c168dbb160e6a97e58e9babfc08dcd60f89cf2c81ff592398940c29e576b870L7-R10): Added patterns to ignore files with `.Designer.cs` and `.generated.cs` extensions, which are typically generated code.