### PR TITLE
move nuget push path to an repo variable

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -52,7 +52,7 @@ jobs:
     - name: Pack Nuget
       run: dotnet pack ClientNoSqlDB/ClientNoSqlDB.csproj --configuration Release 
     - name: publish Nuget Packages to GitHub
-      run: dotnet nuget push ClientNoSqlDB/bin/Release/*.nupkg --source ${{env.package_feed}} --api-key ${{secrets.PUBLISH_NUGET_PACKAGE}} --skip-duplicate      
+      run: dotnet nuget push ${{ vars.UPLOAD_NUGET_PATH }} --source ${{env.package_feed}} --api-key ${{secrets.PUBLISH_NUGET_PACKAGE}} --skip-duplicate      
       if: github.event_name != 'pull_request'
     - name: Upload Artifact
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
This pull request includes a small but important change to the `.github/workflows/dotnet.yml` file. The change modifies the path used for publishing NuGet packages to GitHub.

* [`.github/workflows/dotnet.yml`](diffhunk://#diff-d5a2cea578a0446aad66faf31bf1076ae94c9916b1a3374e342272a6300e8344L55-R55): Updated the `run` command for the "publish Nuget Packages to GitHub" step to use the `${{ vars.UPLOAD_NUGET_PATH }}` variable instead of a hardcoded path.