### PR TITLE
Update dotnet.yml

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -52,7 +52,7 @@ jobs:
     - name: Pack Nuget
       run: dotnet pack ClientNoSqlDB/ClientNoSqlDB.csproj --configuration Release 
     - name: publish Nuget Packages to GitHub
-      run: dotnet nuget push ${{ vars.UPLOAD_NUGET_PATH }} --source ${{env.package_feed}} --api-key ${{secrets.UPLOAD_TO_NUGET}} --skip-duplicate      
+      run: dotnet nuget push ${{ vars.UPLOAD_NUGET_PATH }} --source ${{env.package_feed}} --api-key ${{secrets.PUBLISH_NUGET_PACKAGE}} --skip-duplicate      
       if: github.event_name != 'pull_request'
     - name: Upload Artifact
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
This pull request includes a change to the `.github/workflows/dotnet.yml` file to update the API key used for publishing NuGet packages.

* [`.github/workflows/dotnet.yml`](diffhunk://#diff-d5a2cea578a0446aad66faf31bf1076ae94c9916b1a3374e342272a6300e8344L55-R55): Changed the API key from `${{secrets.UPLOAD_TO_NUGET}}` to `${{secrets.PUBLISH_NUGET_PACKAGE}}` in the `publish Nuget Packages to GitHub` step.