### PR TITLE
Update package versions and refactor project references

### DIFF
--- a/ClientNoSqlDB.Samples.Maui/ClientNoSqlDB.Samples.Maui.csproj
+++ b/ClientNoSqlDB.Samples.Maui/ClientNoSqlDB.Samples.Maui.csproj
@@ -59,9 +59,9 @@
 
 	<ItemGroup>
 		<PackageReference Include="Caliburn.Micro.Maui" Version="5.0.183-beta" />
-		<PackageReference Include="Microsoft.Maui.Controls" Version="9.0.10" />
-		<PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="9.0.10" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.0" />
+		<PackageReference Include="Microsoft.Maui.Controls" Version="9.0.30" />
+		<PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="9.0.30" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.1" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/ClientNoSqlDB.Tests/ClientNoSqlDB.Tests.csproj
+++ b/ClientNoSqlDB.Tests/ClientNoSqlDB.Tests.csproj
@@ -10,8 +10,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.abstractions" Version="2.0.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
@@ -20,6 +18,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="xunit.v3" Version="1.0.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION

This pull request includes updates to package dependencies in both the `ClientNoSqlDB.Samples.Maui` and `ClientNoSqlDB.Tests` projects. The most important changes include updating the Microsoft Maui packages to newer versions and modifying the xUnit package references.

Updates to package dependencies:

* [`ClientNoSqlDB.Samples.Maui/ClientNoSqlDB.Samples.Maui.csproj`](diffhunk://#diff-20d8ce6e000aba564853cdb7614192e036d00b2b6d5e2aed147616e7b7e7ee8aL62-R64): Updated `Microsoft.Maui.Controls` and `Microsoft.Maui.Controls.Compatibility` from version `9.0.10` to `9.0.30`, and `Microsoft.Extensions.Logging.Debug` from version `9.0.0` to `9.0.1`.

* [`ClientNoSqlDB.Tests/ClientNoSqlDB.Tests.csproj`](diffhunk://#diff-0eb605944c765ab3b2ec5bf214332325b9070504452ce7f6fac7e41e0a014e33L13-L14): Removed `xunit` version `2.9.3` and `xunit.abstractions` version `2.0.3`, and added `xunit.v3` version `1.0.1`. [[1]](diffhunk://#diff-0eb605944c765ab3b2ec5bf214332325b9070504452ce7f6fac7e41e0a014e33L13-L14) [[2]](diffhunk://#diff-0eb605944c765ab3b2ec5bf214332325b9070504452ce7f6fac7e41e0a014e33R21)