### PR TITLE
Potential fix for code scanning alert no. 205: Call to System.IO.Path.Combine

### DIFF
--- a/ClientNoSqlDB/Storage/IsolatedStorage/DbTableStorage.cs
+++ b/ClientNoSqlDB/Storage/IsolatedStorage/DbTableStorage.cs
@@ -14,8 +14,8 @@ namespace ClientNoSqlDB.IsolatedStorage
         public DbTableStorage(IsolatedStorageFile storage, string path, string name)
         {
             _storage = storage;
-            _indexName = Path.Combine(path, name + ".index");
-            _dataName = Path.Combine(path, name + ".data");
+            _indexName = Path.Join(path, name + ".index");
+            _dataName = Path.Join(path, name + ".data");
         }
 
         readonly ReaderWriterLockSlim _lock = new ReaderWriterLockSlim();


### PR DESCRIPTION
Potential fix for [https://github.com/Ken-Tucker/ClientNoSqlDB/security/code-scanning/205](https://github.com/Ken-Tucker/ClientNoSqlDB/security/code-scanning/205)

To fix the issue, replace the calls to `Path.Combine` with `Path.Join`. This ensures that all arguments are concatenated correctly, regardless of whether any argument is an absolute path. The change should be made on lines 17 and 18, where `_indexName` and `_dataName` are initialized.

No additional imports or dependencies are required, as `Path.Join` is part of the `System.IO` namespace.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
