### PR TITLE
Potential fix for code scanning alert no. 206: Call to System.IO.Path.Combine

### DIFF
--- a/ClientNoSqlDB/Storage/IsolatedStorage/DbTableStorage.cs
+++ b/ClientNoSqlDB/Storage/IsolatedStorage/DbTableStorage.cs
@@ -14,8 +14,8 @@ namespace ClientNoSqlDB.IsolatedStorage
         public DbTableStorage(IsolatedStorageFile storage, string path, string name)
         {
             _storage = storage;
-            _indexName = Path.Combine(path, name + ".index");
-            _dataName = Path.Combine(path, name + ".data");
+            _indexName = Path.Join(path, name + ".index");
+            _dataName = Path.Join(path, name + ".data");
         }
 
         readonly ReaderWriterLockSlim _lock = new ReaderWriterLockSlim();


### PR DESCRIPTION
Potential fix for [https://github.com/Ken-Tucker/ClientNoSqlDB/security/code-scanning/206](https://github.com/Ken-Tucker/ClientNoSqlDB/security/code-scanning/206)

To fix the issue, replace the calls to `Path.Combine` with `Path.Join`. The `Path.Join` method ensures that all arguments are concatenated without treating absolute paths differently, making it a safer choice for constructing file paths. This change will ensure that `_indexName` and `_dataName` are always constructed as intended, regardless of whether `path` is absolute or relative.

The changes will be made on lines 17 and 18 of the `DbTableStorage` constructor in the file `ClientNoSqlDB/Storage/IsolatedStorage/DbTableStorage.cs`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
