### PR TITLE
Potential fix for code scanning alert no. 204: Call to System.IO.Path.Combine

### DIFF
--- a/ClientNoSqlDB/Storage/FileSystem/DbTableStorage.cs
+++ b/ClientNoSqlDB/Storage/FileSystem/DbTableStorage.cs
@@ -12,8 +12,8 @@ namespace ClientNoSqlDB.FileSystem
 
         public DbTableStorage(string path, string name)
         {
-            _indexName = Path.Combine(path, name + ".index");
-            _dataName = Path.Combine(path, name + ".data");
+            _indexName = Path.Join(path, name + ".index");
+            _dataName = Path.Join(path, name + ".data");
         }
 
         readonly ReaderWriterLockSlim _lock = new ReaderWriterLockSlim();


### PR DESCRIPTION
Potential fix for [https://github.com/Ken-Tucker/ClientNoSqlDB/security/code-scanning/204](https://github.com/Ken-Tucker/ClientNoSqlDB/security/code-scanning/204)

To fix the issue, replace the calls to `Path.Combine` with `Path.Join`. The `Path.Join` method concatenates paths without considering whether any argument is an absolute path, thus avoiding the risk of dropping earlier arguments. This change ensures that the combined paths are always constructed as intended.

The changes will be made in the constructor of the `DbTableStorage` class, specifically on lines 15 and 16. No additional imports or dependencies are required, as `Path.Join` is part of the `System.IO` namespace.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
