### PR TITLE
Potential fix for code scanning alert no. 203: Call to System.IO.Path.Combine

### DIFF
--- a/ClientNoSqlDB/Storage/FileSystem/DbTableStorage.cs
+++ b/ClientNoSqlDB/Storage/FileSystem/DbTableStorage.cs
@@ -12,8 +12,8 @@ namespace ClientNoSqlDB.FileSystem
 
         public DbTableStorage(string path, string name)
         {
-            _indexName = Path.Combine(path, name + ".index");
-            _dataName = Path.Combine(path, name + ".data");
+            _indexName = Path.Join(path, name + ".index");
+            _dataName = Path.Join(path, name + ".data");
         }
 
         readonly ReaderWriterLockSlim _lock = new ReaderWriterLockSlim();


### PR DESCRIPTION
Potential fix for [https://github.com/Ken-Tucker/ClientNoSqlDB/security/code-scanning/203](https://github.com/Ken-Tucker/ClientNoSqlDB/security/code-scanning/203)

To fix the issue, replace the calls to `Path.Combine` with `Path.Join`. This change ensures that the resulting paths are constructed as intended, even if any of the arguments are absolute paths. Specifically:
- Replace `Path.Combine(path, name + ".index")` with `Path.Join(path, name + ".index")`.
- Replace `Path.Combine(path, name + ".data")` with `Path.Join(path, name + ".data")`.

No additional imports or changes are required since `Path.Join` is part of the `System.IO` namespace, which is already imported.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
