### PR TITLE
Potential fix for code scanning alert no. 202: Call to System.IO.Path.Combine

### DIFF
--- a/ClientNoSqlDB/Storage/DbStorage.cs
+++ b/ClientNoSqlDB/Storage/DbStorage.cs
@@ -10,14 +10,14 @@ namespace ClientNoSqlDB
     public IDbSchemaStorage OpenSchema(string path, object home)
     {
 
-      path = Path.Combine("ClientNoSqlDB", path);
+      path = Path.Join("ClientNoSqlDB", path);
       var root = home as string;
 
 
       if (root == null)
         root = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
 
-      return new FileSystem.DbSchemaStorage(Path.Combine(root, path));
+      return new FileSystem.DbSchemaStorage(Path.Join(root, path));
 
     }
 


### PR DESCRIPTION
Potential fix for [https://github.com/Ken-Tucker/ClientNoSqlDB/security/code-scanning/202](https://github.com/Ken-Tucker/ClientNoSqlDB/security/code-scanning/202)

To fix the issue, replace the use of `Path.Combine` with `Path.Join`. The `Path.Join` method does not treat any of its arguments as absolute paths, ensuring that all arguments are concatenated as intended. This change will prevent the unintended dropping of earlier arguments if `path` or `root` happens to be an absolute path.

Specifically:
1. Replace `Path.Combine("ClientNoSqlDB", path)` on line 13 with `Path.Join("ClientNoSqlDB", path)`.
2. Replace `Path.Combine(root, path)` on line 20 with `Path.Join(root, path)`.

No additional imports or dependencies are required, as `Path.Join` is part of the `System.IO` namespace.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
