### PR TITLE
Codeql fixes

### DIFF
--- a/ClientNoSqlDB.Samples.Maui/ClientNoSqlDB.Samples.Maui.csproj
+++ b/ClientNoSqlDB.Samples.Maui/ClientNoSqlDB.Samples.Maui.csproj
@@ -59,9 +59,9 @@
 
 	<ItemGroup>
 		<PackageReference Include="Caliburn.Micro.Maui" Version="5.0.183-beta" />
-		<PackageReference Include="Microsoft.Maui.Controls" Version="9.0.30" />
-		<PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="9.0.30" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.1" />
+		<PackageReference Include="Microsoft.Maui.Controls" Version="9.0.70" />
+		<PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="9.0.70" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.6" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/ClientNoSqlDB.Tests/ClientNoSqlDB.Tests.csproj
+++ b/ClientNoSqlDB.Tests/ClientNoSqlDB.Tests.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
@@ -18,7 +18,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="xunit.v3" Version="1.0.1" />
+    <PackageReference Include="xunit.v3" Version="2.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ClientNoSqlDB/ClientNoSqlDB.csproj
+++ b/ClientNoSqlDB/ClientNoSqlDB.csproj
@@ -36,7 +36,7 @@
 		</None>
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Sbom.Targets" Version="3.1.0">
+		<PackageReference Include="Microsoft.Sbom.Targets" Version="4.0.3">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>

--- a/ClientNoSqlDB/Storage/DbStorage.cs
+++ b/ClientNoSqlDB/Storage/DbStorage.cs
@@ -9,10 +9,11 @@ namespace ClientNoSqlDB
 
         public IDbSchemaStorage OpenSchema(string path, object home)
         {
-#if netstandard20
-            path = Path.Combine("ClientNoSqlDB", path);
-#elif NET8_0_OR_GREATER
+
+#if NET8_0_OR_GREATER
             path = Path.Join("ClientNoSqlDB", path);
+#else
+            path = Path.Combine("ClientNoSqlDB", path);
 #endif
             var root = home as string;
 

--- a/ClientNoSqlDB/Storage/DbStorage.cs
+++ b/ClientNoSqlDB/Storage/DbStorage.cs
@@ -4,34 +4,41 @@ using System.IO;
 
 namespace ClientNoSqlDB
 {
-  class DbStorage : IDbStorage
-  {
-
-    public IDbSchemaStorage OpenSchema(string path, object home)
+    class DbStorage : IDbStorage
     {
 
-      path = Path.Combine("ClientNoSqlDB", path);
-      var root = home as string;
+        public IDbSchemaStorage OpenSchema(string path, object home)
+        {
+#if netstandard20
+            path = Path.Combine("ClientNoSqlDB", path);
+#elif NET8_0_OR_GREATER
+            path = Path.Join("ClientNoSqlDB", path);
+#endif
+            var root = home as string;
 
 
-      if (root == null)
-        root = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+            if (root == null)
+                root = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
 
-      return new FileSystem.DbSchemaStorage(Path.Combine(root, path));
 
+#if NET8_0_OR_GREATER
+            return new FileSystem.DbSchemaStorage(Path.Join(root, path));
+#else
+            return new FileSystem.DbSchemaStorage(Path.Combine(root, path));
+#endif     
+        }
+
+        public bool IncreaseQuotaTo(long quota)
+        {
+
+            return true;
+
+        }
+
+        public bool HasEnoughQuota(long quota)
+        {
+
+            return true;
+        }
     }
-
-    public bool IncreaseQuotaTo(long quota)
-    {
-
-      return true;
-
-    }
-
-    public bool HasEnoughQuota(long quota)
-    {
-
-      return true;
-    }
-  }
 }

--- a/ClientNoSqlDB/Storage/FileSystem/DbTableStorage.cs
+++ b/ClientNoSqlDB/Storage/FileSystem/DbTableStorage.cs
@@ -12,8 +12,13 @@ namespace ClientNoSqlDB.FileSystem
 
         public DbTableStorage(string path, string name)
         {
+#if netstandard20
             _indexName = Path.Combine(path, name + ".index");
             _dataName = Path.Combine(path, name + ".data");
+#elif NET8_0_OR_GREATER
+            _indexName = Path.Join(path, name + ".index");
+            _dataName = Path.Join(path, name + ".data");
+#endif
         }
 
         readonly ReaderWriterLockSlim _lock = new ReaderWriterLockSlim();

--- a/ClientNoSqlDB/Storage/FileSystem/DbTableStorage.cs
+++ b/ClientNoSqlDB/Storage/FileSystem/DbTableStorage.cs
@@ -12,12 +12,13 @@ namespace ClientNoSqlDB.FileSystem
 
         public DbTableStorage(string path, string name)
         {
-#if netstandard20
-            _indexName = Path.Combine(path, name + ".index");
-            _dataName = Path.Combine(path, name + ".data");
-#elif NET8_0_OR_GREATER
+
+#if NET8_0_OR_GREATER
             _indexName = Path.Join(path, name + ".index");
             _dataName = Path.Join(path, name + ".data");
+#else
+            _indexName = Path.Combine(path, name + ".index");
+            _dataName = Path.Combine(path, name + ".data");
 #endif
         }
 

--- a/ClientNoSqlDB/Storage/IsolatedStorage/DbTableStorage.cs
+++ b/ClientNoSqlDB/Storage/IsolatedStorage/DbTableStorage.cs
@@ -14,8 +14,13 @@ namespace ClientNoSqlDB.IsolatedStorage
         public DbTableStorage(IsolatedStorageFile storage, string path, string name)
         {
             _storage = storage;
+#if netstandard20
             _indexName = Path.Combine(path, name + ".index");
             _dataName = Path.Combine(path, name + ".data");
+#elif NET8_0_OR_GREATER 
+            _indexName = Path.Join(path, name + ".index");
+            _dataName = Path.Join(path, name + ".data");
+#endif
         }
 
         readonly ReaderWriterLockSlim _lock = new ReaderWriterLockSlim();

--- a/ClientNoSqlDB/Storage/IsolatedStorage/DbTableStorage.cs
+++ b/ClientNoSqlDB/Storage/IsolatedStorage/DbTableStorage.cs
@@ -14,12 +14,12 @@ namespace ClientNoSqlDB.IsolatedStorage
         public DbTableStorage(IsolatedStorageFile storage, string path, string name)
         {
             _storage = storage;
-#if netstandard20
-            _indexName = Path.Combine(path, name + ".index");
-            _dataName = Path.Combine(path, name + ".data");
-#elif NET8_0_OR_GREATER 
+#if NET8_0_OR_GREATER 
             _indexName = Path.Join(path, name + ".index");
             _dataName = Path.Join(path, name + ".data");
+#else
+            _indexName = Path.Combine(path, name + ".index");
+            _dataName = Path.Combine(path, name + ".data");
 #endif
         }
 


### PR DESCRIPTION
This pull request updates package dependencies across multiple projects and introduces conditional logic to improve compatibility with .NET 8.0 or greater. The most important changes include upgrading package versions and modifying path handling logic to use `Path.Join` for newer .NET versions.

### Package Updates:

* [`ClientNoSqlDB.Samples.Maui.csproj`](diffhunk://#diff-20d8ce6e000aba564853cdb7614192e036d00b2b6d5e2aed147616e7b7e7ee8aL62-R64): Updated versions of `Microsoft.Maui.Controls`, `Microsoft.Maui.Controls.Compatibility`, and `Microsoft.Extensions.Logging.Debug` to ensure compatibility with newer releases.
* [`ClientNoSqlDB.Tests.csproj`](diffhunk://#diff-0eb605944c765ab3b2ec5bf214332325b9070504452ce7f6fac7e41e0a014e33L12-R21): Upgraded `Microsoft.NET.Test.Sdk`, `xunit.runner.visualstudio`, and `xunit.v3` to newer versions for improved testing capabilities.
* [`ClientNoSqlDB.csproj`](diffhunk://#diff-d353cf54352e7e85363261975cde754487abe0f4a3aefbd75d17e33d49f99cceL39-R39): Updated `Microsoft.Sbom.Targets` package to version `4.0.3` for enhanced SBOM (Software Bill of Materials) support.

### Compatibility Enhancements for .NET 8.0:

* [`DbStorage.cs`](diffhunk://#diff-18663a185545d4a271e036ab40e080ced69b61928c08bd77650a896cb2785016R13-R29): Added conditional logic to use `Path.Join` instead of `Path.Combine` when targeting .NET 8.0 or greater, improving path handling consistency.
* `DbTableStorage.cs` (both `FileSystem` and `IsolatedStorage` versions): Implemented similar conditional logic for path construction, ensuring compatibility with .NET 8.0 or greater. [[1]](diffhunk://#diff-cb7694c7ba62063a5e21dc0e130934026bc24ac581a84aaf4947a9b7957011dbR15-R22) [[2]](diffhunk://#diff-ec636d41c122178fce680a4bf8ce9624d9d9fc4bf061ef0a7388ef090d5b8812R17-R23)