### PR TITLE
Potential fix for code scanning alert no. 213: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-net
 
 name: .NET
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Ken-Tucker/ClientNoSqlDB/security/code-scanning/213](https://github.com/Ken-Tucker/ClientNoSqlDB/security/code-scanning/213)

To fix this issue, add an explicit `permissions` block to the `.github/workflows/dotnet.yml`. This should be placed at the workflow root (directly under `name`, before `on:`), ensuring that all jobs default to the least privileged access for the GITHUB_TOKEN. The minimal permissions for most build workflows is `contents: read`, allowing read-only access to the repository contents. If any steps require more privilege (e.g., PR or issue modification) you should add only those specific permission keys. In this workflow, since it does not interact with issues, PRs, or require write access to repository contents, only `contents: read` is needed. You should insert:

```yaml
permissions:
  contents: read
```

on a new line after the `name: .NET` declaration.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
