### PR TITLE
Potential fix for code scanning alert no. 212: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Deployment
 
 concurrency:


### PR DESCRIPTION
Potential fix for [https://github.com/Ken-Tucker/ClientNoSqlDB/security/code-scanning/212](https://github.com/Ken-Tucker/ClientNoSqlDB/security/code-scanning/212)

To fix the problem, add an explicit `permissions` block to the workflow, restricting GITHUB_TOKEN to the minimal required privileges. The recommended approach is to set this at the root level in the workflow (just under `name:` or `on:`), unless certain jobs require additional permissions, in which case their individual job permissions should be set accordingly. For this workflow, `contents: read` is sufficient for most steps (checking out code, downloading artifacts), and pushing to Nuget uses a separate API key. Add:

```yaml
permissions:
  contents: read
```

directly underneath the workflow `name:` declaration. This will ensure that all jobs in this workflow restrict GITHUB_TOKEN to read-only operations for repository contents, following the principle of least privilege and resolving the CodeQL warning.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
