### PR TITLE
Add vulnerability check for .NET packages

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -45,6 +45,11 @@ jobs:
       run: dotnet workload install maui maui-android maui-ios maui-tizen maui-maccatalyst maui-windows android --source https://api.nuget.org/v3/index.json
     - name: list workloads
       run: dotnet workload list 
+    - name: Checking for external vulnerabilites
+      run: |
+        dotnet list package --vulnerable --include-transitive -s https://www.myget.org/F/caliburn-micro-builds/api/v3/index.json -s https://api.nuget.org/v3/index.json 2>&1 | tee vuln.log
+        echo "Analyze dotnet list package..."
+        ! grep -q -i "has the following vulnerable packages" vuln.log
     - name: Restore dependencies
       run: dotnet restore -s https://www.myget.org/F/caliburn-micro-builds/api/v3/index.json -s https://api.nuget.org/v3/index.json
     - name: Build


### PR DESCRIPTION
This pull request adds an additional security check to the `.github/workflows/dotnet.yml` workflow to automatically detect external package vulnerabilities before restoring dependencies and building the project.

Security improvements:

* Added a step named "Checking for external vulnerabilites" to the GitHub Actions workflow that uses `dotnet list package --vulnerable` to scan for vulnerable packages (including transitive dependencies) and fails the workflow if any are found. This helps catch security issues early in the CI process.