### PR TITLE
Upgrade target framework from net9.0 to net10.0

### DIFF
--- a/ClientNoSqlDB.Samples.Maui/ClientNoSqlDB.Samples.Maui.csproj
+++ b/ClientNoSqlDB.Samples.Maui/ClientNoSqlDB.Samples.Maui.csproj
@@ -59,7 +59,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Caliburn.Micro.Maui" Version="5.0.183-beta" />
-		<PackageReference Include="Microsoft.Maui.Controls" Version="10.0.50" />
+		<PackageReference Include="Microsoft.Maui.Controls" Version="10.0.11" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.5" />
 	</ItemGroup>
 

--- a/ClientNoSqlDB.Samples.Maui/ClientNoSqlDB.Samples.Maui.csproj
+++ b/ClientNoSqlDB.Samples.Maui/ClientNoSqlDB.Samples.Maui.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net10.0-ios;;net10.0-android36.0</TargetFrameworks>
+		<TargetFrameworks>net10.0-ios;net10.0-android</TargetFrameworks>
 		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net10.0-windows10.0.22621.0</TargetFrameworks>
 		<!-- Uncomment to also build the tizen app. You will need to install tizen by following this: https://github.com/Samsung/Tizen.NET -->
 		<!-- <TargetFrameworks>$(TargetFrameworks);net8.0-tizen</TargetFrameworks> -->
@@ -58,8 +58,8 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Caliburn.Micro.Maui" Version="5.0.183-beta" />
-		<PackageReference Include="Microsoft.Maui.Controls" Version="10.0.11" />
+		<PackageReference Include="Caliburn.Micro.Maui" Version="5.0.231-beta" />
+		<PackageReference Include="Microsoft.Maui.Controls" Version="10.0.50" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.5" />
 	</ItemGroup>
 

--- a/ClientNoSqlDB.Samples.Maui/ClientNoSqlDB.Samples.Maui.csproj
+++ b/ClientNoSqlDB.Samples.Maui/ClientNoSqlDB.Samples.Maui.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<TargetFrameworks>net10.0-ios;net10.0-android</TargetFrameworks>

--- a/ClientNoSqlDB.Samples.Maui/ClientNoSqlDB.Samples.Maui.csproj
+++ b/ClientNoSqlDB.Samples.Maui/ClientNoSqlDB.Samples.Maui.csproj
@@ -59,8 +59,8 @@
 
 	<ItemGroup>
 		<PackageReference Include="Caliburn.Micro.Maui" Version="5.0.183-beta" />
-		<PackageReference Include="Microsoft.Maui.Controls" Version="10.0.11" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.1" />
+		<PackageReference Include="Microsoft.Maui.Controls" Version="10.0.50" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.5" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/ClientNoSqlDB.Samples.NetCore/ClientNoSqlDB.Samples.NetCore.csproj
+++ b/ClientNoSqlDB.Samples.NetCore/ClientNoSqlDB.Samples.NetCore.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/ClientNoSqlDB.Tests/ClientNoSqlDB.Tests.csproj
+++ b/ClientNoSqlDB.Tests/ClientNoSqlDB.Tests.csproj
@@ -11,6 +11,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
     <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.5.2" />
+    <PackageReference Include="Microsoft.Testing.Platform" Version="2.1.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/ClientNoSqlDB.Tests/ClientNoSqlDB.Tests.csproj
+++ b/ClientNoSqlDB.Tests/ClientNoSqlDB.Tests.csproj
@@ -1,30 +1,31 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
+	<PropertyGroup>
+		<TargetFramework>net10.0</TargetFramework>
 
-    <IsPackable>false</IsPackable>
-  </PropertyGroup>
+		<IsPackable>false</IsPackable>
+	</PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
-    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.5.2" />
-    <PackageReference Include="Microsoft.Testing.Platform" Version="2.1.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.1.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="xunit.v3" Version="3.2.2" />
+    <PackageReference Include="xunit.v3" Version="3.2.1" />
   </ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\ClientNoSqlDB\ClientNoSqlDB.csproj" />
-  </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Update="Nerdbank.GitVersioning" Version="3.9.50" />
-  </ItemGroup>
-
+	<ItemGroup>
+		<ProjectReference Include="..\ClientNoSqlDB\ClientNoSqlDB.csproj" />
+	</ItemGroup>
+	<ItemGroup>
+		<PackageReference Update="Nerdbank.GitVersioning" Version="3.9.50" />
+	</ItemGroup>
 </Project>
+
+
+
+
+

--- a/ClientNoSqlDB.Tests/ClientNoSqlDB.Tests.csproj
+++ b/ClientNoSqlDB.Tests/ClientNoSqlDB.Tests.csproj
@@ -9,13 +9,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.1.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.5.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="xunit.v3" Version="3.2.1" />
+    <PackageReference Include="xunit.v3" Version="3.2.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ClientNoSqlDB.Tests/DbTests.cs
+++ b/ClientNoSqlDB.Tests/DbTests.cs
@@ -1,4 +1,4 @@
-﻿using ClientNoSqlDB;
+using ClientNoSqlDB;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -8,7 +8,6 @@ using Xunit;
 
 namespace ClientNoSql.Tests
 {
-
     public class AsynchronousAttribute : Attribute { }
 
     public class WorkItemTest
@@ -49,9 +48,6 @@ namespace ClientNoSql.Tests
             TestPKKey(i => i.KeyGuid, (o, v) => o.KeyGuid = v, Guid.NewGuid());
             TestPKKey(i => i.KeyGuidN, (o, v) => o.KeyGuidN = v, Guid.NewGuid());
             TestPKKey(i => i.KeyGuidN, (o, v) => o.KeyGuidN = v, null);
-
-
-
         }
 
         private void TestPKKey<T>(Expression<Func<MyDataKeys, T>> pkGetter, Action<MyDataKeys, T> pkSetter, T key)
@@ -71,7 +67,6 @@ namespace ClientNoSql.Tests
             db.Purge();
         }
 
-
         private void PurgeDb()
         {
             using (var i = Prepare())
@@ -88,20 +83,17 @@ namespace ClientNoSql.Tests
             db.Dispose();
         }
 
-
         private void OpenDb()
         {
             db = new DbInstance("My Database");
             db.Initialize();
         }
 
-
         private void OpenDbComplexPath()
         {
             db = new DbInstance(@"My Database\My Schema");
             db.Initialize();
         }
-
 
         [Fact]
         public void DoubleOpenDbComplexPath()
@@ -127,7 +119,6 @@ namespace ClientNoSql.Tests
             db = new DbInstance(@"My Database\My Schema");
 
             db.Initialize();
-
 
             Assert.Throws<InvalidOperationException>(() => db.Map<MyData>().Automap(i => i.Id));
         }
@@ -229,7 +220,6 @@ namespace ClientNoSql.Tests
             Assert.True(a.OrderBy(i => i.Id).Select(i => i.Id).SequenceEqual(b.OrderBy(i => i.Id).Select(i => i.Id)));
         }
 
-
         private void LoadData()
         {
             var localTable = db.Table<MyData>();
@@ -249,7 +239,6 @@ namespace ClientNoSql.Tests
                 var obj = table.LoadByKey(key);
 
                 Assert.Equal(newObj.Name, obj.Name);
-
             });
         }
 
@@ -288,19 +277,16 @@ namespace ClientNoSql.Tests
             });
         }
 
-
         private void Compact()
         {
             table.Compact();
         }
-
 
         private void CheckInfo()
         {
             _ = table.GetInfo();
             _ = db.GetInfo();
         }
-
 
         [Fact]
         public void RoundTripNulls()
@@ -663,7 +649,6 @@ namespace ClientNoSql.Tests
             table.Save(obj);
 
             Assert.True(table.DeleteByKey((object)obj.Id));
-
         }
 
         public void Dispose()

--- a/ClientNoSqlDB.Tests/DbTests.cs
+++ b/ClientNoSqlDB.Tests/DbTests.cs
@@ -1,5 +1,8 @@
 ﻿using ClientNoSqlDB;
+using System;
+using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using System.Linq.Expressions;
 using Xunit;
 

--- a/ClientNoSqlDB.Tests/DbTests2.cs
+++ b/ClientNoSqlDB.Tests/DbTests2.cs
@@ -1,5 +1,6 @@
 ﻿using ClientNoSqlDB;
 using ClientNoSqlDB.Serialization;
+using System;
 using Xunit;
 
 namespace ClientNoSql.Tests

--- a/ClientNoSqlDB.Tests/DbTests3.cs
+++ b/ClientNoSqlDB.Tests/DbTests3.cs
@@ -1,5 +1,6 @@
 ﻿using ClientNoSqlDB;
 using ClientNoSqlDB.Serialization;
+using System;
 using Xunit;
 
 namespace ClientNoSql.Tests

--- a/ClientNoSqlDB/ClientNoSqlDB.csproj
+++ b/ClientNoSqlDB/ClientNoSqlDB.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>netstandard2.0;net8.0;net9.0</TargetFrameworks>
+		<TargetFrameworks>netstandard2.0;net8.0;net9.0;net10.0</TargetFrameworks>
 		<PackOnBuild>false</PackOnBuild>
 		<PackageId>ClientNoSqlDB</PackageId>
 		<PackageVersion>3.0</PackageVersion>


### PR DESCRIPTION
This pull request updates the target framework of the `ClientNoSqlDB.Samples.NetCore` project to use the latest .NET version.

- Project configuration:
  * Changed the `TargetFramework` in `ClientNoSqlDB.Samples.NetCore.csproj` from `net9.0` to `net10.0` to target the latest .NET runtime.