### PR TITLE
Update test infra, dependencies, and Visual Studio version

### DIFF
--- a/ClientNoSqlDB.Samples.Maui/ClientNoSqlDB.Samples.Maui.csproj
+++ b/ClientNoSqlDB.Samples.Maui/ClientNoSqlDB.Samples.Maui.csproj
@@ -59,8 +59,8 @@
 
 	<ItemGroup>
 		<PackageReference Include="Caliburn.Micro.Maui" Version="5.0.231-beta" />
-		<PackageReference Include="Microsoft.Maui.Controls" Version="10.0.50" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.5" />
+		<PackageReference Include="Microsoft.Maui.Controls" Version="10.0.51" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.6" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/ClientNoSqlDB.Tests/ClientNoSqlDB.Tests.csproj
+++ b/ClientNoSqlDB.Tests/ClientNoSqlDB.Tests.csproj
@@ -1,19 +1,21 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net10.0</TargetFramework>
-
+		<TargetFramework>net9.0</TargetFramework>
+		<IsTestingPlatformApplication>true</IsTestingPlatformApplication>
+		<IsTestProject>true</IsTestProject>
 		<IsPackable>false</IsPackable>
+		<TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
+		<OutputType>Exe</OutputType>
 	</PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.1.0" />
+    <PackageReference Include="Microsoft.Testing.Platform" Version="1.9.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="xunit.v3" Version="3.2.1" />
+    <PackageReference Include="xunit.v3" Version="3.2.2" />
   </ItemGroup>
 
 

--- a/ClientNoSqlDB.Tests/ClientNoSqlDB.Tests.csproj
+++ b/ClientNoSqlDB.Tests/ClientNoSqlDB.Tests.csproj
@@ -11,6 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Testing.Platform" Version="1.9.1" />
+    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" Version="1.9.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/ClientNoSqlDB.sln
+++ b/ClientNoSqlDB.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 17
-VisualStudioVersion = 17.3.32929.385
+# Visual Studio Version 18
+VisualStudioVersion = 18.4.11626.88
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ClientNoSqlDB", "ClientNoSqlDB\ClientNoSqlDB.csproj", "{FDAE74D5-A07B-4ADD-B6B8-89B663F0DFE7}"
 EndProject


### PR DESCRIPTION
- Bump Microsoft.Maui.Controls and Logging.Debug in Samples project
- Migrate Tests project to .NET 9, add new testing platform props
- Replace legacy test SDKs with Microsoft.Testing.Platform 1.9.1
- Update xunit.v3 to 3.2.2
- Update solution file for Visual Studio 18.4 compatibility