### PR TITLE
fix unit tests

### DIFF
--- a/ClientNoSqlDB.Samples.Maui/ClientNoSqlDB.Samples.Maui.csproj
+++ b/ClientNoSqlDB.Samples.Maui/ClientNoSqlDB.Samples.Maui.csproj
@@ -59,8 +59,8 @@
 
 	<ItemGroup>
 		<PackageReference Include="Caliburn.Micro.Maui" Version="5.0.231-beta" />
-		<PackageReference Include="Microsoft.Maui.Controls" Version="10.0.50" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.5" />
+		<PackageReference Include="Microsoft.Maui.Controls" Version="10.0.60" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.8" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/ClientNoSqlDB.Tests/ClientNoSqlDB.Tests.csproj
+++ b/ClientNoSqlDB.Tests/ClientNoSqlDB.Tests.csproj
@@ -7,13 +7,16 @@
 	</PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.1.0" />
+    <PackageReference Include="coverlet.collector" Version="10.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="xunit.v3" Version="3.2.1" />
+    <PackageReference Include="xunit.v3" Version="3.2.2" />
   </ItemGroup>
 
 


### PR DESCRIPTION
This pull request updates several NuGet package dependencies to newer versions in both the main Maui sample project and the test project. The updates include important packages related to .NET MAUI, logging, and testing frameworks.

Dependency updates:

**Main Maui sample project (`ClientNoSqlDB.Samples.Maui.csproj`):**
* Upgraded `Microsoft.Maui.Controls` from version 10.0.50 to 10.0.60.
* Upgraded `Microsoft.Extensions.Logging.Debug` from version 10.0.5 to 10.0.8.

**Test project (`ClientNoSqlDB.Tests.csproj`):**
* Replaced `Microsoft.Testing.Extensions.CodeCoverage` with `coverlet.collector` (version 10.0.0) for code coverage, and added appropriate asset and privacy settings.
* Upgraded `Microsoft.NET.Test.Sdk` from version 18.0.1 to 18.5.1.
* Upgraded `xunit.v3` from version 3.2.1 to 3.2.2.